### PR TITLE
Add: ghc-8.6.4 resolvers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ os:
 env:
   - STACK_YAML=stack-ghc7.10.3.yaml
   - STACK_YAML=stack-ghc8.0.2.yaml
+  - STACK_YAML=stack-ghc8.6.4.yaml
 
 # Caching so the next build will be fast too.
 cache:

--- a/socket-unix.cabal
+++ b/socket-unix.cabal
@@ -3,7 +3,7 @@ version:             0.2.0.0
 synopsis:            Unix domain sockets
 description:         A Unix domain socket extension for the socket library
 homepage:            https://github.com/vyacheslavhashov/haskell-socket-unix#readme
-license:             MIT 
+license:             MIT
 license-file:        LICENSE
 author:              Vyacheslav Hashov
 maintainer:          vyacheslavhashov@gmail.com
@@ -43,8 +43,8 @@ test-suite default
   build-depends:       base         >= 4.7      && < 5
                      , socket       >= 0.8.0.0  && < 0.9.0.0
                      , socket-unix
-                     , tasty        >= 0.11     && < 0.12
-                     , tasty-hunit  >= 0.9      && < 0.10
+                     , tasty        >= 0.11     && < 1.3
+                     , tasty-hunit  >= 0.9      && < 0.11
                      , bytestring   >= 0.10.0.0 && < 0.11
                      , unix         >= 2.7      && < 3.0
                      , async        >= 2.0      && < 2.3
@@ -63,8 +63,8 @@ test-suite threaded
   build-depends:       base         >= 4.7      && < 5
                      , socket       >= 0.8.0.0  && < 0.9.0.0
                      , socket-unix
-                     , tasty        >= 0.11     && < 0.12
-                     , tasty-hunit  >= 0.9      && < 0.10
+                     , tasty        >= 0.11     && < 1.3
+                     , tasty-hunit  >= 0.9      && < 0.11
                      , bytestring   >= 0.10.0.0 && < 0.11
                      , unix         >= 2.7      && < 3.0
                      , async        >= 2.0      && < 2.3

--- a/stack-ghc8.6.4.yaml
+++ b/stack-ghc8.6.4.yaml
@@ -10,4 +10,3 @@ flags: {}
 
 # Extra package databases containing global packages
 extra-package-dbs: []
-

--- a/stack-ghc8.6.4.yaml
+++ b/stack-ghc8.6.4.yaml
@@ -1,0 +1,13 @@
+resolver: lts-13.16
+
+packages:
+- '.'
+extra-deps:
+- socket-0.8.2.0
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,0 @@
-stack-ghc8.0.2.yaml


### PR DESCRIPTION
Adds GHC 8.6.4 resolvers and a travis environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vyacheslavhashov/haskell-socket-unix/6)
<!-- Reviewable:end -->
